### PR TITLE
feat: send dummy data every minute to GSheets, add EasyStorage

### DIFF
--- a/app/app-service/service.js
+++ b/app/app-service/service.js
@@ -4,7 +4,7 @@ import { BasePage } from "@zeppos/zml/base-page";
 import { HeartRate, Sleep } from "@zos/sensor";
 import { getProfile } from '@zos/user';
 import { getDeviceInfo } from '@zos/device';
-import { settingsLib } from "@zeppos/zml/base-side";
+import { sendDataToGoogleSheets } from '../app-side/google-api';
 
 const timeSensor = new Time();
 const url = 'insert_ngrok_url_here/post'; // replace with your ngrok tunnel url
@@ -12,33 +12,41 @@ const url = 'insert_ngrok_url_here/post'; // replace with your ngrok tunnel url
 AppService(
     BasePage({
         onInit() {
-            console.log('app service onInit');
-            console.log('The settings have');
-
-
+            this.log('app service onInit');
             timeSensor.onPerMinute(() => {
-                this.log("app service running");
-                // this.sendMetrics();
-                this.request({ method: "GET_TOKEN" }).then((res) => {
-                    console.log('[App Service] GET_TOKEN ==>', JSON.stringify(res));
+                this.log(
+                    `Time report: ${timeSensor.getHours()}:${timeSensor.getMinutes().toString().padStart(2, '0')}:${timeSensor.getSeconds().toString().padStart(2, '0')}`
+                )
+
+                this.request({
+                    method: "POST_TO_GOOGLE",
+                    body: this.getMetrics()
+                }).then((res) => {
+                    this.log('[App Service] POST_TO_GOOGLE ==>', res);
                 }).catch((err) => {
-                    console.log('GET_TOKEN errored', err);
+                    this.log('POST_TO_GOOGLE errored', err);
                 });
 
-                console.log(
-                    `Time report: ${timeSensor.getHours()}:${timeSensor.getMinutes()}:${timeSensor.getSeconds()}`
-                )
+                // If we need to instead use side-service:
+                // this.request({ method: "GET_TOKEN" }).then((res) => {
+                //     const token = res.token;
+                //     this.log('[App Service] GET_TOKEN ==>', res);
+                //     this.log('[App Service] token ==>', res.token);
+                //     this.sendToGoogleSheets(token);
+                // }).catch((err) => {
+                //     this.log('GET_TOKEN errored', err);
+                // });
+
             });
         },
-        sendMetrics() {
-            const startTime = new Date().getTime();
+        getMetrics() {
             const deviceInfo = getDeviceInfo();
             const heartRate = new HeartRate();
             const sleep = new Sleep();
 
             sleep.updateInfo();
 
-            const reqBody = {
+            return {
                 recordTime: Math.floor(new Date().getTime() / 1000),
                 user: getProfile(),
                 device: deviceInfo,
@@ -49,11 +57,12 @@ AppService(
                 sleepStageList: sleep.getStageConstantObj(),
                 sleepStatus: sleep.getSleepingStatus(),
             };
-
+        },
+        sendMetricsToServer() {
             this.httpRequest({
                 method: 'POST',
                 url: url,
-                body: JSON.stringify(reqBody),
+                body: JSON.stringify(this.getMetrics()),
                 headers: {
                     'Content-Type': 'application/json',
                 }

--- a/app/app-side/index.js
+++ b/app/app-side/index.js
@@ -1,26 +1,31 @@
 import { BaseSideService } from "@zeppos/zml/base-side";
+import { sendDataToGoogleSheets } from "./google-api";
 
 AppSideService(
   BaseSideService({
     onInit() {
-      console.log('app side service invoke onInit')
-      // settings.settingsStorage.addListener('change', ({ k, newVal, oldVal }) => {
-      //   console.log('settings change', k, newVal, oldVal)
-      // });
-      // console.log('settings token', settings.settingsStorage.getItem('googleAuthToken'))
+      console.log('app side service invoke onInit');
     },
 
     onRun() { },
 
     onDestroy() { },
 
-    onRequest(req, res) {
+    async onRequest(req, res) {
       console.log(`Method ==> ${req.method}`)
       if (req.method === "POST_TO_GOOGLE") {
         console.log('req.body', req.body)
+        const accessToken = settings.settingsStorage.getItem('googleAuthData').access_token;
+        const response = await sendDataToGoogleSheets(accessToken, req.body);
+        if (response.success) {
+          console.log('Successfully wrote to Google Sheets');
+          res(null, { status: 'success' });
+        } else {
+          console.error('Failed to write to Google Sheets');
+          res(null, { status: 'error', data: response.data });
+        }
       } else if (req.method === "GET_TOKEN") {
-        settings.settingsStorage.setItem('hello', 'world')
-        res(null, { token: settings.settingsStorage.getItem('googleAuthData') })
+        res(null, { token: settings.settingsStorage.getItem('googleAuthData').access_token })
       }
     }
   }),

--- a/app/app.js
+++ b/app/app.js
@@ -1,8 +1,13 @@
 import { BaseApp } from '@zeppos/zml/base-app'
 
+import EasyStorage from "@silver-zepp/easy-storage";
+const storage = new EasyStorage();
+
 App(
   BaseApp({
-    globalData: {},
+    globalData: {
+      storage: storage
+    },
     onCreate() {
       console.log('app invoke onCreate')
     },

--- a/app/app.json
+++ b/app/app.json
@@ -18,7 +18,8 @@
 		"data:user.hd.sleep",
 		"data:user.info",
 		"data:os.device.info",
-		"device:os.notification"
+		"device:os.notification",
+		"device:os.local_storage"
 	],
 	"runtime": {
 		"apiVersion": {

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
 		"@zeppos/device-types": "^3.0.0"
 	},
 	"dependencies": {
+		"@silver-zepp/easy-storage": "^1.6.7-b",
 		"@zeppos/zml": "^0.0.29"
 	}
 }

--- a/app/page/index.js
+++ b/app/page/index.js
@@ -6,6 +6,7 @@ import { START_BUTTON } from 'zosLoader:./index.[pf].layout.js';
 
 const permissions = ["device:os.bg_service"];
 const service = "app-service/service";
+const storage = getApp()._options.globalData.storage;
 
 Page(
   BasePage({
@@ -16,7 +17,6 @@ Page(
         click_func: () => {
           console.log('fetch button clicked');
           if (checkPermissions()) {
-            this.getToken();
             startAppService();
           } else {
             console.log('permission denied');
@@ -32,16 +32,6 @@ Page(
     onDestroy() {
       console.log('page onDestroy invoked');
     },
-
-    getToken() {
-      console.log('getToken invoked');
-      this.request({ method: "GET_TOKEN" })
-        .then((res) => {
-          console.log('GET_TOKEN', JSON.stringify(res));
-        }).catch((err) => {
-          console.log('GET_TOKEN errored', err);
-        });
-    }
   }),
 )
 
@@ -49,6 +39,7 @@ Page(
 const startAppService = () => {
   console.log('startAppService invoked');
   console.log(`starting service: ${service}`);
+  storage.setKey('googleAuthData', 'test123');
   appService.start({
     url: service,
     complete_func: (info) => {

--- a/app/setting/index.js
+++ b/app/setting/index.js
@@ -18,7 +18,7 @@ AppSettingsPage({
         console.log('state:', this.state);
     },
     build(props) {
-        this.setState(props)
+        this.setState(props);
         const signInBtn = Button({
             label: this.state.googleAuthData ? 'Sign Out' : 'Sign In',
             style: {
@@ -55,7 +55,9 @@ AppSettingsPage({
             oAuthParams: {
                 redirect_uri: GOOGLE_API_REDIRECT_URI,
                 response_type: 'code',
+                include_granted_scopes: 'true',
                 access_type: 'offline',
+                prompt: 'consent'
             },
             onAccessToken: (token) => {
                 console.log('onAccessToken', token)

--- a/app/setting/index.js
+++ b/app/setting/index.js
@@ -7,11 +7,15 @@ AppSettingsPage({
         googleAuthData: null,
     },
     setState(props) {
-        this.state.props = props
-        if (props.settingsStorage.getItem('googleAuthData')) {
-            this.state.googleAuthData = props.settingsStorage.getItem('googleAuthData')
+        this.state.props = props;
+        const storedAuthData = props.settingsStorage.getItem('googleAuthData');
+        if (storedAuthData) {
+            this.state.googleAuthData = storedAuthData;
         }
-        console.log('state:', this.state)
+        if (this.isTokenExpired()) {
+            this.state.googleAuthData = null;
+        }
+        console.log('state:', this.state);
     },
     build(props) {
         this.setState(props)
@@ -78,5 +82,14 @@ AppSettingsPage({
                 clearBtn
             ]
         )
-    }
+    },
+    isTokenExpired() {
+        const authData = this.state.googleAuthData;
+        if (!authData || !authData.expires_at) {
+            return true;
+        }
+        const now = new Date();
+        const expiresAt = new Date(authData.expires_at);
+        return now >= expiresAt;
+    },
 })


### PR DESCRIPTION
1. send fake data every minute to GSheets, set up basic framework to support API call to PUT data.
     note: this sends data via app-side, not app-service, which may be a problem when using on real watch (need to test)
3. add EasyStorage dependency (remember run `npm i` in `/app`)
4. simplify some of the code